### PR TITLE
Update zuluCrypt.spec

### DIFF
--- a/zuluCrypt.spec
+++ b/zuluCrypt.spec
@@ -1,37 +1,68 @@
+#
+# Spec file for package Dolphin Emulator
+#
+# Copyright © 2011-2015 Francis Banyikwa <mhogomchungu@gmail.com>
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 Name:           zuluCrypt
-Version: 4.7.5
-Release: 0
+Version:        4.7.5
+Release:        0
 Summary:        Qt GUI front end to cryptsetup
 License:        GPL-2.0+
 Group:          Productivity/Security
-Source:         zuluCrypt-%{version}.tar.bz2
+Source:         %{name}-%{version}.tar.xz
 Source100:      zuluCrypt-rpmlint
-URL:            http://code.google.com/p/zulucrypt/
-BuildRoot:      %{_topdir}/%{name}-%{version}
+URL:            https://github.com/mhogomchungu/zuluCrypt
 
-%define zuluCrypt_plugins zuluCrypt_plugins
-%define libversion 3.2.0
-%define srcname zuluCrypt
-%define libname lib%srcname%libversion
-%define libnamedev lib%{srcname}%{libversion}-devel
+%define libversion 3_2_0
+%define srcname zulucrypt
+%define libname %srcname%libversion
+%define libnamedev %{srcname}%{libversion}-devel
 
 #You may want to add dependencies for kwallet,gnome-keyring and pwquality below
 #if you want to include optional functionality they provide.
-%if 0%{?fedora}
-BuildRequires:  cmake gcc gcc-c++ qt-devel glibc-devel libblkid-devel cryptsetup-luks-devel
-#BuildRequires:  cmake gcc gcc-c++ qt-devel gnome-keyring-devel glibc-devel libmount-devel libblkid-devel cryptsetup-luks-devel
-%else
-BuildRequires:  cmake gcc gcc-c++ libqt4-devel glibc-devel libblkid-devel libcryptsetup-devel libtcplay-devel
+
+BuildRequires: cmake
+BuildRequires: device-mapper-devel
+BuildRequires: gcc
+BuildRequires: gcc-c++
+BuildRequires: glibc-devel
+BuildRequires: libblkid-devel
+BuildRequires: libmount-devel
+BuildRequires: libgcrypt-devel
+BuildRequires: libsecret-devel
+BuildRequires: libpwquality-devel
+BuildRequires: pkgconfig(QtCore)
+BuildRequires: pkgconfig(QtGui)
+
+%if 0%{?fedora} 
+BuildRequires: cryptsetup-luks-devel
+%endif
+
+%if 0%{?suse_version}
+BuildRequires: libcryptsetup-devel
 %endif
 
 %description
 zuluCrypt is a front end to cryptsetup.
-It makes it easier to use cryptsetup by providing a Qt based GUI and a simpler to use cli front end to cryptsetup and tcplay.
+It makes it easier to use cryptsetup by providing a Qt-based GUI and a simpler to use CLI front end to cryptsetup.
 It does the same thing truecrypt does but without licensing problems or requiring a user to setup sudo for it or presenting root's password.
 This package contains the applications.
 
 %package -n %{libnamedev}
-Requires:       %{libname} = %{version}
+Requires:       lib%{libname} = %{version}
 Summary:        Development library package
 Group:          Development/Libraries/C and C++
 
@@ -43,23 +74,16 @@ Summary:        Library for %{name}
 Group:          Productivity/Security
 
 %description -n %{libname}
-This package contains libraries that provide higher level access to cryptsetup API and provide mounting/unmounting API
+This package contains libraries that provide higher level access to cryptsetup API and provide mounting/unmounting API 
 to easy opening and closing of volumes
 
-%package -n %{zuluCrypt_plugins}
-Requires:       %{libname}
-Summary:        various zuluCrypt plugins
-
-%description -n %{zuluCrypt_plugins}
-zuluCrypt plugins
-
 %prep
-%setup -q -n zuluCrypt-%{version}
+%setup -q
 
 %build
 mkdir build
 cd build
-cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_BUILD_TYPE=Release ../
+cmake .. -DCMAKE_INSTALL_PREFIX:PATH=/usr -DUDEVSUPPORT=true -DCMAKE_BUILD_TYPE=Release
 
 %install
 cd build
@@ -83,16 +107,28 @@ sbin/ldconfig
 
 %clean
 rm -rf %{buildroot}
-rm -rf $RPM_BUILD_DIR/%{name}-%{version}
+rm -rf $RPM_BUILD_DIR/zuluCrypt
 
-%files
+%files 
 %defattr(0755,root,root)
 %{_bindir}/zuluMount-gui
 %{_bindir}/zuluMount-cli
 %{_bindir}/zuluCrypt-gui
 %{_bindir}/zuluCrypt-cli
 %{_bindir}/zuluSafe-cli
+
+#It is necessary to comment in the below two lines if you want to build these optional features
+#and all dependencies are met.
+#%%{_libdir}/zuluCrypt/kwallet
+%{_libdir}/zuluCrypt/keyring
 %{_libdir}/zuluCrypt/zuluCrypt-testKey
+%{_libdir}/zuluCrypt/keykeyfile
+%{_libdir}/zuluCrypt/keydialog-qt
+%{_libdir}/zuluCrypt/luks
+%{_libdir}/zuluCrypt/steghide
+%{_libdir}/zuluCrypt/tomb
+%{_libdir}/zuluCrypt/gpg
+%{_libdir}/zuluCrypt/hmac
 
 %{_datadir}/applications/zuluCrypt.desktop
 %{_datadir}/applications/zuluMount.desktop
@@ -102,50 +138,34 @@ rm -rf $RPM_BUILD_DIR/%{name}-%{version}
 %{_mandir}/man1/*
 %defattr(0644,root,root)
 
-%files -n %{zuluCrypt_plugins}
-%defattr(0755,root,root)
-#
-# you may need to comment plugins you dont want to build
-#
-%{_libdir}/zuluCrypt/gpg
-%{_libdir}/zuluCrypt/keydialog-qt
-%{_libdir}/zuluCrypt/keyring
-%{_libdir}/zuluCrypt/keykeyfile
-# %{_libdir}/zuluCrypt/kwallet
-%{_libdir}/zuluCrypt/luks
-%{_libdir}/zuluCrypt/steghide
-%{_libdir}/zuluCrypt/tomb
-
 %files -n %{libname}
-%defattr(0755,root,root)
-%dir %{_libdir}/zuluCrypt
 %defattr(0644,root,root)
+%dir %{_libdir}/zuluCrypt
 %{_libdir}/libzuluCrypt.so.*
 %{_libdir}/libzuluCrypt-exe.so.*
 %{_libdir}/libzuluCryptPluginManager.so.*
 
 %files -n %{libnamedev}
-%defattr(0755,root,root)
-%dir %{_includedir}/zuluCrypt
 %defattr(0644,root,root)
+%dir %{_includedir}/zuluCrypt
 %{_includedir}/zuluCrypt/libzuluCrypt.h
 %{_includedir}/zuluCrypt/libzuluCrypt-exe.h
 %{_includedir}/zuluCrypt/libzuluCryptPluginManager.h
 %{_libdir}/libzuluCryptPluginManager.so
+#%%{_libdir}/libzuluCryptPluginManager-static.a
 %{_libdir}/libzuluCrypt.so
 %{_libdir}/libzuluCrypt-exe.so
+#%%{_libdir}/libzuluCrypt-static.a
+#%%{_libdir}/libzuluCrypt-exe-static.a
 %{_libdir}/pkgconfig/libzuluCrypt.pc
 
 %changelog
-* Thu May 1 2014 mhogomchungu@gmail.com
- - update to version 4.7.0
-* Fri Jul 19 2013 mhogomchungu@gmail.com
- - update to version 4.6.5
-* Sun Jun  2 2013 mhogomchungu@gmail.com
- - update to version 4.6.4
-* Thu May 30 2013 mhogomchungu@gmail.com
- - upate to version 4.6.3
-* Fri Mar 15 2013 mhogomchungu@gmail.com
- - upate to version 4.6.2
-* Mon Jan 14 2012 mhogomchungu@gmail.com
- - update to version 4.6.0
+
+# openSUSE is strict about the date format used.
+# To do: Fix date format.
+
+#* Thu May  1 2014 mhogomchungu@gmail.com
+#* Fri Mar 15 2013 mhogomchungu@gmail.com
+#- upate to version 4.6.2
+#* Mon Jan 14 2012 mhogomchungu@gmail.com
+#- update to version 4.6.0

--- a/zuluCrypt.spec
+++ b/zuluCrypt.spec
@@ -1,8 +1,8 @@
 #
-# Spec file for package Dolphin Emulator
+# Spec file for package zuluCrypt
 #
 # Copyright © 2011-2015 Francis Banyikwa <mhogomchungu@gmail.com>
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 2 of the License, or
@@ -47,7 +47,7 @@ BuildRequires: libpwquality-devel
 BuildRequires: pkgconfig(QtCore)
 BuildRequires: pkgconfig(QtGui)
 
-%if 0%{?fedora} 
+%if 0%{?fedora}
 BuildRequires: cryptsetup-luks-devel
 %endif
 
@@ -74,7 +74,7 @@ Summary:        Library for %{name}
 Group:          Productivity/Security
 
 %description -n %{libname}
-This package contains libraries that provide higher level access to cryptsetup API and provide mounting/unmounting API 
+This package contains libraries that provide higher level access to cryptsetup API and provide mounting/unmounting API
 to easy opening and closing of volumes
 
 %prep
@@ -109,7 +109,7 @@ sbin/ldconfig
 rm -rf %{buildroot}
 rm -rf $RPM_BUILD_DIR/zuluCrypt
 
-%files 
+%files
 %defattr(0755,root,root)
 %{_bindir}/zuluMount-gui
 %{_bindir}/zuluMount-cli


### PR DESCRIPTION
(Based on newer version in OBS)

Fixes missing dependency
Split BuildRequires into cross-distro and distro-specific parts
Comment out changelog (date format not accepted by openSUSE)
Added copyright header