### PR TITLE
zuluCrypt-gui: make fs combobox in createvolume dialog editable

### DIFF
--- a/zuluCrypt-gui/createvolume.ui
+++ b/zuluCrypt-gui/createvolume.ui
@@ -186,6 +186,9 @@
      <height>31</height>
     </rect>
    </property>
+   <property name="editable">
+    <bool>true</bool>
+   </property>
   </widget>
   <widget class="QComboBox" name="comboBoxVolumeType">
    <property name="geometry">


### PR DESCRIPTION
This allows the user to type in abitrary file system name in addition to choosing from a predefined list, which should make it a little bit easier to create a volume with less popular file systems.