### PR TITLE
fix typo on linux/limits.h

### DIFF
--- a/zuluCrypt-cli/bin/volumes.c
+++ b/zuluCrypt-cli/bin/volumes.c
@@ -29,7 +29,7 @@
 #include <unistd.h>
 #include <libintl.h>
 #include <locale.h>
-#include "<linux/limits.h>"
+#include <linux/limits.h>
 
 #include <blkid/blkid.h>
 


### PR DESCRIPTION
sorry mate, typo in there.
It caused travis to fail: https://travis-ci.org/mhogomchungu/zuluCrypt/jobs/331978345#L854
Maybe you enable travis for PR automatically and merge only sane versions?

