### PR TITLE
Fix ordering of linker flags for zuluCrypt library

### DIFF
--- a/zuluCrypt-cli/CMakeLists.txt
+++ b/zuluCrypt-cli/CMakeLists.txt
@@ -123,7 +123,7 @@
  set_target_properties( zuluCrypt-exe PROPERTIES SOVERSION ${LIB_VERSION} )
 
  if( STATIC_ZULUPLAY )
-	TARGET_LINK_LIBRARIES( zuluCrypt     String StringList Process ${cryptsetup_lib} ${blkid} ${uuid_lib} ${devmapper_lib} -lgcrypt zuluplay-static )
+	TARGET_LINK_LIBRARIES( zuluCrypt     String StringList Process zuluplay-static ${cryptsetup_lib} ${blkid} ${uuid_lib} ${devmapper_lib} -lgcrypt )
  else()
 	TARGET_LINK_LIBRARIES( zuluCrypt     String StringList Process ${cryptsetup_lib} ${blkid} ${uuid_lib} ${devmapper_lib} ${TCPLAY_LIB} -lgcrypt -lzuluplay )
  endif()


### PR DESCRIPTION
Static libraries have to be listed before dynamic ones. Otherwise, when compiling with the '-Wl,--as-needed' flag, the linker doesn't consider the functions used in zuluplay-static when determining that libgcrypt is not used and thus need not be linked against.

Fixes #110