### PR TITLE
Add extern to variable declaration in header

### DIFF
--- a/zuluCrypt-cli/bin/security.h
+++ b/zuluCrypt-cli/bin/security.h
@@ -35,7 +35,7 @@ extern "C" {
  * set the function to be called when an attempt to evelate or downgrade privileges fail
  * zuluCryptSecurityPrivilegeElevationError global variable is defined in security.c
  */
-void ( *zuluCryptSecurityPrivilegeElevationError )( const char * ) ;
+extern void ( *zuluCryptSecurityPrivilegeElevationError )( const char * ) ;
 
 void zuluCryptSecuritySetPrivilegeElevationErrorFunction( void ( * ) ( const char * ) ) ;
 


### PR DESCRIPTION
GCC 10 now defaults to using `-fno-common` when building, which will cause a build error with ZuluCrypt due to `security.h`. The fix is just to add an extern to the variable declaration since it is actually initialized and contained inside `security.c`. This allows the package to compile with `-fno-common` enabled. 

(this is breaking the build in Fedora Rawhide currently).