### PR TITLE
Fix a typo in an example

### DIFF
--- a/zuluMount-cli.1
+++ b/zuluMount-cli.1
@@ -61,7 +61,7 @@ mount a volume  : zuluMount-cli -m -d /dev/sdc1
 .br
 unmount a volume: zuluMount-cli -u -d /dev/sdc1
 .br
-mount and encrypted volume with a key "xyz" : zuluMount-cli -m -d /dev/sdc2 -p xyz
+mount an encrypted volume with a key "xyz" : zuluMount-cli -m -d /dev/sdc2 -p xyz
 .br
 
 .SH COPYRIGHT


### PR DESCRIPTION
In the encrypted volume example, 'and' should be 'an'.