### PR TITLE
Fix mount-prefix=home for `sudo zuluMount-cli`

### DIFF
--- a/zuluCrypt-cli/bin/open_volume.c
+++ b/zuluCrypt-cli/bin/open_volume.c
@@ -362,6 +362,30 @@ int zuluCryptEXEOpenVolume( const struct_opts * opts,const char * mapping_name,u
 		/*
 		* zuluCryptCreateMountPoint() is defined in create_mount_point.c
 		*/
+
+        // get mountpoint for user, not for root
+        int found = 0;
+        int found_at;
+        int ii = 0;
+        while (!found) {
+            ii++;
+            if (!memcmp(opts->env[ii], "SUDO_UID", 8)) {
+                found_at = ii;
+                printf("%s\n",opts->env[ii]);
+                found = 1;
+            }
+        }
+
+        if (found == 1) {
+            char uidsenv[20];
+            char uids[20];
+            strcpy(uidsenv, opts->env[found_at]);
+            memcpy(uids, uidsenv+9,strlen(uidsenv));
+            printf("%s\n", uidsenv);
+            printf("%s\n", uids);
+            uid = StringConvertToInt(uids);
+        }
+
 		*m_point = zuluCryptCreateMountPoint( device,mount_point,m_opts,uid ) ;
 
 		mount_point = StringContent( *m_point ) ;

--- a/zuluCrypt-cli/bin/open_volume.c
+++ b/zuluCrypt-cli/bin/open_volume.c
@@ -371,7 +371,6 @@ int zuluCryptEXEOpenVolume( const struct_opts * opts,const char * mapping_name,u
             ii++;
             if (!memcmp(opts->env[ii], "SUDO_UID", 8)) {
                 found_at = ii;
-                printf("%s\n",opts->env[ii]);
                 found = 1;
             }
         }
@@ -381,8 +380,6 @@ int zuluCryptEXEOpenVolume( const struct_opts * opts,const char * mapping_name,u
             char uids[20];
             strcpy(uidsenv, opts->env[found_at]);
             memcpy(uids, uidsenv+9,strlen(uidsenv));
-            printf("%s\n", uidsenv);
-            printf("%s\n", uids);
             uid = StringConvertToInt(uids);
         }
 

--- a/zuluMount-cli/crypto_umount.c
+++ b/zuluMount-cli/crypto_umount.c
@@ -62,12 +62,12 @@ int zuluMountCryptoUMount( ARGS * args )
     // get mountpoint for user, not for root
     int found = 0;
     int found_at;
-    int ii = 0;
-    while (!found) {
-        ii++;
-        if (!memcmp(opts->env[ii], "SUDO_UID", 8)) {
+    for (int ii=0; StringListContentAt(args->env,ii) != StringListContentAtLast(args->env); ii++) {
+        //printf("%s\n",StringListContentAt(stx,ii));
+
+        if (!memcmp(StringListContentAt(args->env, ii), "SUDO_UID", 8)) {
             found_at = ii;
-            printf("%s\n",opts->env[ii]);
+            printf("%s\n",StringListContentAt(args->env, ii));
             found = 1;
         }
     }
@@ -75,12 +75,13 @@ int zuluMountCryptoUMount( ARGS * args )
     if (found == 1) {
         char uidsenv[20];
         char uids[20];
-        strcpy(uidsenv, opts->env[found_at]);
+        strcpy(uidsenv, StringListContentAt(args->env, found_at));
         memcpy(uids, uidsenv+9,strlen(uidsenv));
         printf("%s\n", uidsenv);
         printf("%s\n", uids);
         uid = StringConvertToInt(uids);
     }
+
 
 	st = zuluCryptEXECloseVolume( device,mapping_name,uid ) ;
 

--- a/zuluMount-cli/crypto_umount.c
+++ b/zuluMount-cli/crypto_umount.c
@@ -67,7 +67,6 @@ int zuluMountCryptoUMount( ARGS * args )
 
         if (!memcmp(StringListContentAt(args->env, ii), "SUDO_UID", 8)) {
             found_at = ii;
-            printf("%s\n",StringListContentAt(args->env, ii));
             found = 1;
         }
     }
@@ -77,8 +76,6 @@ int zuluMountCryptoUMount( ARGS * args )
         char uids[20];
         strcpy(uidsenv, StringListContentAt(args->env, found_at));
         memcpy(uids, uidsenv+9,strlen(uidsenv));
-        printf("%s\n", uidsenv);
-        printf("%s\n", uids);
         uid = StringConvertToInt(uids);
     }
 

--- a/zuluMount-cli/crypto_umount.c
+++ b/zuluMount-cli/crypto_umount.c
@@ -59,6 +59,29 @@ int zuluMountCryptoUMount( ARGS * args )
 	/*
 	 * zuluCryptEXECloseVolume() is defined in ../zuluCrypt-cli/bin/close_volume.c
 	 */
+    // get mountpoint for user, not for root
+    int found = 0;
+    int found_at;
+    int ii = 0;
+    while (!found) {
+        ii++;
+        if (!memcmp(opts->env[ii], "SUDO_UID", 8)) {
+            found_at = ii;
+            printf("%s\n",opts->env[ii]);
+            found = 1;
+        }
+    }
+
+    if (found == 1) {
+        char uidsenv[20];
+        char uids[20];
+        strcpy(uidsenv, opts->env[found_at]);
+        memcpy(uids, uidsenv+9,strlen(uidsenv));
+        printf("%s\n", uidsenv);
+        printf("%s\n", uids);
+        uid = StringConvertToInt(uids);
+    }
+
 	st = zuluCryptEXECloseVolume( device,mapping_name,uid ) ;
 
 	StringDelete( &str ) ;


### PR DESCRIPTION
This enables a sudo call to mount the encrypted volume within the calling user's home directory.

EXAMPLE
`user1@hostname$ sudo zuluMount-cli -m -d Documents/file_container -z mount_dir -e mount-prefix=home`
will result in the encrypted volume being mounted at /home/user1/mount_dir.

I was unable to accomplish this without running as sudo, and with the sudo wrapper, the uid is set to 0.