### PR TITLE
Update de_DE.ts

### DIFF
--- a/translations/zuluCrypt/de_DE.ts
+++ b/translations/zuluCrypt/de_DE.ts
@@ -1221,7 +1221,7 @@ Da Sie jetzt wissen, was Sie tun, brechen Sie den Vorgang ab, wenn es sein muss.
     <message>
         <location filename="../../zuluCrypt-gui/createvolume.cpp" line="152"/>
         <source>LUKS2+External Header</source>
-        <translation>LUKS1 + Externer Header</translation>
+        <translation>LUKS2+Externe Kopfdaten</translation>
     </message>
     <message>
         <location filename="../../zuluCrypt-gui/createvolume.cpp" line="154"/>


### PR DESCRIPTION
1) Corrected wrong LUKS version in the German translation.

2) Removed Space characters before and after ,,+" to unify it with the English naming  (also complying with the German translation for ,,LUKS1+External Header", line 1214)

3) Differing German translations for ,,External Header": -,,Externe Kopfdaten" (line 1214)
-,,Externer Header" (line 1224)

I replaced ,,Header" with ,,Kopfdaten" as in line 1214. The German translation uses ,,Kopfdaten" also at other places.


In my opinion ,,Kopfdaten" is not common in German. Instead ,,Header" is used.
 
Maybe it is an option to provide additional explanation in brackets ,,(Header)" in the German translation.

If ,,(Header)" is added as explanation, than it should be also added at all other places in the translation.