### PR TITLE
Fix linking against QtWidgets library for QT6

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -26,16 +26,20 @@ set( CMAKE_CXX_EXTENSIONS OFF)
 if(BUILD_WITH_QT6)
 
 	add_library( plugin STATIC mainwindow.h mainwindow.ui mainwindow.cpp )
+
+	TARGET_LINK_LIBRARIES( plugin sharedObject ${Qt6Widgets_LIBRARIES} ${Qt6Core_LIBRARIES} )
 else()
 	QT5_WRAP_UI( UI mainwindow.ui )
 	QT5_WRAP_CPP( MOC mainwindow.h )
 
 	add_library( plugin STATIC ${MOC} ${UI} mainwindow.cpp )
+
+	TARGET_LINK_LIBRARIES( plugin sharedObject ${Qt5Widgets_LIBRARIES} ${Qt5Core_LIBRARIES} )
 endif()
 
 set_target_properties( plugin PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64 -Wextra -Wall -s -fPIC -pthread  -pedantic " )
 
-TARGET_LINK_LIBRARIES( plugin sharedObject ${Qt5Widgets_LIBRARIES} ${QtCore_LIBRARIES} zuluCryptPluginManager ${blkid} )
+TARGET_LINK_LIBRARIES( plugin sharedObject zuluCryptPluginManager ${blkid} )
 
 add_subdirectory( gpg )
 add_subdirectory( keykeyfile )

--- a/plugins/keydialog-qt/CMakeLists.txt
+++ b/plugins/keydialog-qt/CMakeLists.txt
@@ -17,7 +17,7 @@ else()
 	QT5_ADD_RESOURCES( ICON icon.qrc )
 
 	add_executable( keydialog-qt ${ICON} ${MOC} ${UI} main.cpp mainwindow.cpp )
-	TARGET_LINK_LIBRARIES( keydialog-qt sharedObject ${Qt5Widgets_LIBRARIES} ${QtCore_LIBRARIES} zuluCryptPluginManager ${blkid} )
+	TARGET_LINK_LIBRARIES( keydialog-qt sharedObject ${Qt5Widgets_LIBRARIES} ${Qt5Core_LIBRARIES} zuluCryptPluginManager ${blkid} )
 	#set_target_properties( keydialog-qt PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}" )
 	set_target_properties( keydialog-qt PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64 -Wall -s -fPIE -pthread -pedantic " )
 endif()


### PR DESCRIPTION
When building ZuluCrypt with QT6 in Fedora, I encountered the following errors when linking:
```
/usr/bin/ld: /tmp/ccgEHnOi.ltrans0.ltrans.o: undefined reference to symbol '_ZN6QFrame14setFrameShadowENS_6ShadowE@@Qt_6'
/usr/bin/ld: /usr/lib64/libQt6Widgets.so.6: error adding symbols: DSO missing from command line
/usr/bin/ld: /tmp/ccO0QIxY.ltrans0.ltrans.o: undefined reference to symbol '_ZN6QFrame14setFrameShadowENS_6ShadowE@@Qt_6'
/usr/bin/ld: /usr/lib64/libQt6Widgets.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
gmake[2]: *** [plugins/keykeyfile/CMakeFiles/keykeyfile.dir/build.make:159: plugins/keykeyfile/keykeyfile] Error 1
gmake[2]: Leaving directory '/builddir/build/BUILD/zulucrypt-7.0.0-build/zuluCrypt-7.0.0/redhat-linux-build'
gmake[1]: *** [CMakeFiles/Makefile2:1359: plugins/keykeyfile/CMakeFiles/keykeyfile.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
collect2: error: ld returned 1 exit status
gmake[2]: *** [plugins/steghide/CMakeFiles/steghide.dir/build.make:159: plugins/steghide/steghide] Error 1
gmake[2]: Leaving directory '/builddir/build/BUILD/zulucrypt-7.0.0-build/zuluCrypt-7.0.0/redhat-linux-build'
gmake[1]: *** [CMakeFiles/Makefile2:1445: plugins/steghide/CMakeFiles/steghide.dir/all] Error 2
/usr/bin/ld: /tmp/ccgZ9Xkr.ltrans0.ltrans.o: undefined reference to symbol '_ZN6QFrame14setFrameShadowENS_6ShadowE@@Qt_6'
/usr/bin/ld: /usr/lib64/libQt6Widgets.so.6: error adding symbols: DSO missing from command line
/usr/bin/ld: /tmp/cc7tjXD4.ltrans0.ltrans.o: undefined reference to symbol '_ZN6QFrame14setFrameShadowENS_6ShadowE@@Qt_6'
/usr/bin/ld: /usr/lib64/libQt6Widgets.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
gmake[2]: *** [plugins/gpg/CMakeFiles/gpg.dir/build.make:159: plugins/gpg/gpg] Error 1
gmake[2]: Leaving directory '/builddir/build/BUILD/zulucrypt-7.0.0-build/zuluCrypt-7.0.0/redhat-linux-build'
collect2: error: ld returned 1 exit status
gmake[1]: *** [CMakeFiles/Makefile2:1273: plugins/gpg/CMakeFiles/gpg.dir/all] Error 2
gmake[2]: *** [plugins/hmac/CMakeFiles/hmac.dir/build.make:159: plugins/hmac/hmac] Error 1
gmake[2]: Leaving directory '/builddir/build/BUILD/zulucrypt-7.0.0-build/zuluCrypt-7.0.0/redhat-linux-build'
gmake[1]: *** [CMakeFiles/Makefile2:1617: plugins/hmac/CMakeFiles/hmac.dir/all] Error 2
/usr/bin/ld: /tmp/ccepoKhL.ltrans0.ltrans.o: undefined reference to symbol '_ZN6QFrame14setFrameShadowENS_6ShadowE@@Qt_6'
/usr/bin/ld: /usr/lib64/libQt6Widgets.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
gmake[2]: *** [plugins/tomb/CMakeFiles/tomb.dir/build.make:159: plugins/tomb/tomb] Error 1
gmake[2]: Leaving directory '/builddir/build/BUILD/zulucrypt-7.0.0-build/zuluCrypt-7.0.0/redhat-linux-build'
gmake[1]: *** [CMakeFiles/Makefile2:1531: plugins/tomb/CMakeFiles/tomb.dir/all] Error 2
```

This seems to be because the QT6 widgets library is not being appended to the linker properly:
```
[100%] Linking CXX executable tomb
cd /builddir/build/BUILD/zulucrypt-7.0.0-build/zuluCrypt-7.0.0/redhat-linux-build/plugins/tomb && /usr/bin/cmake -E cmake_link_script CMakeFiles/tomb.dir/link.txt --verbose=1
/usr/bin/g++ -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -mtls-dialect=gnu2 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -DNDEBUG -Wl,-z,relro -Wl,--as-needed  -Wl,-z,pack-relative-relocs -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -Wl,--build-id=sha1 -specs=/usr/lib/rpm/redhat/redhat-package-notes CMakeFiles/tomb.dir/tomb_autogen/mocs_compilation.cpp.o CMakeFiles/tomb.dir/main.cpp.o CMakeFiles/tomb.dir/tomb_autogen/5TB7W6GN3K/qrc_icon.cpp.o -o tomb  -Wl,-rpath,/builddir/build/BUILD/zulucrypt-7.0.0-build/zuluCrypt-7.0.0/redhat-linux-build/zuluCrypt-cli: ../libplugin.a ../../zuluCrypt-gui/sharedObjects/libsharedObject.a -lgcrypt -llxqt-wallet -lblkid /usr/lib64/libQt6Network.so.6.8.0 ../../external_libraries/tasks/libmhogomchungu_task.a /usr/lib64/libQt6Core.so.6.8.0 ../../zuluCrypt-cli/libzuluCryptPluginManager.so.1.0.0 ../../zuluCrypt-cli/libSocket.a ../../zuluCrypt-cli/libProcess.a -pthread ../../zuluCrypt-cli/libString.a /usr/lib64/libblkid.so
```

This PR updates the target library dependencies to now handle the QT6 libraries as well as the QT5 libraries.