### PR TITLE
Update LXQT headers to work with LXQT 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -380,6 +380,12 @@ if( NOT NOGUI )
 				include_directories( ${LXQT_WALLET_INCLUDEDIR} )
 				link_directories( ${LXQT_WALLET_LIBDIR} )
 
+				# lxqt-wallet 4.0.0 renamed a header from "lxqtwallet.h" to "lxqt-wallet.h",
+				# so this is needed to choose the right header to include when compiling.
+				if( LXQT_WALLET_VERSION VERSION_GREATER "4.0.0" )
+					add_compile_definitions( LXQT_WALLET_HYPHEN_HEADER )
+				endif()
+
 				message( STATUS "---------------------------------------------------------------------------" )
 				message( STATUS "lxqt wallet support will be provided by an external libary" )
 				message( STATUS "---------------------------------------------------------------------------" )

--- a/plugins/network_key/network_key.h
+++ b/plugins/network_key/network_key.h
@@ -37,7 +37,12 @@
 
 #include "../../zuluCrypt-cli/pluginManager/libzuluCryptPluginManager.h"
 #include "../../zuluCrypt-cli/utility/socket/socket.h"
+
+#ifdef LXQT_WALLET_HYPHEN_HEADER
+#include "lxqt-wallet.h"
+#else
 #include "lxqtwallet.h"
+#endif
 
 #define BUFFER_SIZE 1024
 

--- a/zuluCrypt-gui/cryptfiles.cpp
+++ b/zuluCrypt-gui/cryptfiles.cpp
@@ -38,7 +38,12 @@
 #include "utility.h"
 #include "openvolume.h"
 #include "dialogmsg.h"
+
+#ifdef LXQT_WALLET_HYPHEN_HEADER
+#include "lxqt-wallet.h"
+#else
 #include "lxqtwallet.h"
+#endif
 
 #include "plugin.h"
 


### PR DESCRIPTION
When rebuilding zulucrypt against LXQT Wallet 4.0 as part of the Fedora update, I encountered a compiler error because the lxqt backend header was renamed from "lxqtwallet.h" to "lxqt-wallet.h":
```
[ 97%] Building CXX object zuluCrypt-gui/CMakeFiles/zuluCrypt-gui.dir/createvolumedialog.cpp.o
cd /builddir/build/BUILD/zulucrypt-7.0.0-build/zuluCrypt-7.0.0/redhat-linux-build/zuluCrypt-gui && /usr/bin/g++ -DQT_CORE_LIB -DQT_DBUS_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_NO_DEBUG -DQT_WIDGETS_LIB -D_DEFAULT_SOURCE -D_FILE_OFFSET_BITS=64 -I/builddir/build/BUILD/zulucrypt-7.0.0-build/zuluCrypt-7.0.0/redhat-linux-build/zuluCrypt-gui -I/builddir/build/BUILD/zulucrypt-7.0.0-build/zuluCrypt-7.0.0/zuluCrypt-gui -I/builddir/build/BUILD/zulucrypt-7.0.0-build/zuluCrypt-7.0.0/redhat-linux-build/zuluCrypt-gui/zuluCrypt-gui_autogen/include -I/builddir/build/BUILD/zulucrypt-7.0.0-build/zuluCrypt-7.0.0/redhat-linux-build -I/builddir/build/BUILD/zulucrypt-7.0.0-build/zuluCrypt-7.0.0/external_libraries/tcplay -I/usr/include/qt6/QtDBus -I/usr/include/lxqt -I/builddir/build/BUILD/zulucrypt-7.0.0-build/zuluCrypt-7.0.0/external_libraries/tasks -isystem /usr/include/qt6/QtWidgets -isystem /usr/include/qt6 -isystem /usr/include/qt6/QtCore -isystem /usr/include/qt6/QtGui -isystem /usr/include/qt6/QtNetwork -isystem /usr/lib64/qt6/mkspecs/linux-g++ -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -mtls-dialect=gnu2 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -DNDEBUG -std=c++17   -fstack-protector-all --param ssp-buffer-size=4 -Wextra -Wall -pedantic -I/builddir/build/BUILD/zulucrypt-7.0.0-build/zuluCrypt-7.0.0/redhat-linux-build/zuluCrypt-gui/ -D_FILE_OFFSET_BITS=64 -Wextra -Wall -s -fPIC -pedantic -MD -MT zuluCrypt-gui/CMakeFiles/zuluCrypt-gui.dir/createvolumedialog.cpp.o -MF CMakeFiles/zuluCrypt-gui.dir/createvolumedialog.cpp.o.d -o CMakeFiles/zuluCrypt-gui.dir/createvolumedialog.cpp.o -c /builddir/build/BUILD/zulucrypt-7.0.0-build/zuluCrypt-7.0.0/zuluCrypt-gui/createvolumedialog.cpp
/builddir/build/BUILD/zulucrypt-7.0.0-build/zuluCrypt-7.0.0/zuluCrypt-gui/cryptfiles.cpp:41:10: fatal error: lxqtwallet.h: No such file or directory
   41 | #include "lxqtwallet.h"
      |          ^~~~~~~~~~~~~~
compilation terminated.
```

This is an attempt to fix that error while still supporting the 3.0 lxqtwallet versions. This makes the Fedora builds pass with lxqtwallet 4.0.0 with no further errors now.