### PR TITLE
Update build instructions for Ubuntu/Debian

### DIFF
--- a/debian.upstream/BUILD_INSTRUCTIONS
+++ b/debian.upstream/BUILD_INSTRUCTIONS
@@ -25,7 +25,7 @@ HOW TO BUILD A ZULUCRYPT PACKAGE ON UBUNTU OR ANY OTHER DEBIAN BASED DISTRIBUTIO
 
    ******************************************************************************************************
 
-   sudo apt-get -f install tar xz-utils libpwquality-dev libblkid-dev qtbase5-dev qttools5-dev gcc g++ libcryptsetup-dev cmake libgcrypt11-dev libsecret-1-dev pkg-config libdevmapper-dev uuid-dev libudev-dev chrpath bzip2 debhelper
+   sudo apt-get -f install tar xz-utils libpwquality-dev libblkid-dev qtbase5-dev qttools5-dev gcc g++ libcryptsetup-dev cmake libgcrypt20-dev libsecret-1-dev pkg-config libdevmapper-dev uuid-dev libudev-dev chrpath bzip2 debhelper
 
    ******************************************************************************************************
 
@@ -81,7 +81,7 @@ HOW TO BUILD A ZULUCRYPT PACKAGE ON DEBIAN OR ANY OTHER DEBIAN BASED DISTRIBUTIO
 
    ******************************************************************************************************
 
-   su -c "apt-get -f install tar xz-utils libpwquality-dev libblkid-dev qtbase5-dev qttools5-dev gcc g++ libcryptsetup-dev cmake libgcrypt11-dev libsecret-1-dev pkg-config libdevmapper-dev uuid-dev libudev-dev chrpath bzip2 debhelper"
+   su -c "apt-get -f install tar xz-utils libpwquality-dev libblkid-dev qtbase5-dev qttools5-dev gcc g++ libcryptsetup-dev cmake libgcrypt20-dev libsecret-1-dev pkg-config libdevmapper-dev uuid-dev libudev-dev chrpath bzip2 debhelper"
 
    ******************************************************************************************************
 

--- a/debian.upstream/changelog
+++ b/debian.upstream/changelog
@@ -1,3 +1,9 @@
+zulucrypt (7.1.0-1) UNRELEASED; urgency=low
+  * New Features
+     -- Fix a regression that prevented a password with non ascii character to no longer work.
+     -- Fix a bug that prevented some operations when zuluCrypt-cli was invoked with sudo.
+     -- Fix a zuluPolkit crash when it is invoked with a newer version of polkit.
+
 zulucrypt (5.4.0-1) UNRELEASED; urgency=low
   [Mhogo Mchungu]
   * New Features

--- a/debian.upstream/control
+++ b/debian.upstream/control
@@ -3,7 +3,7 @@ Section: admin
 Priority: extra
 Maintainer: Mhogo Mchungu <mhogomchungu@gmail.com>
 Uploaders:
-Build-Depends: chrpath, debhelper (>= 9), cmake, pkg-config, libcryptsetup-dev, libblkid-dev, libdevmapper-dev, uuid-dev, libgcrypt11-dev, libudev-dev, bzip2, qtbase5-dev, qttools5-dev, libsecret-1-dev, libpwquality-dev
+Build-Depends: chrpath, debhelper (>= 9), cmake, pkg-config, libcryptsetup-dev, libblkid-dev, libdevmapper-dev, uuid-dev, libgcrypt20-dev, libudev-dev, bzip2, qtbase5-dev, qttools5-dev, libsecret-1-dev, libpwquality-dev
 Standards-Version: 3.9.8
 Homepage: http://mhogomchungu.github.io/zuluCrypt/
 Vcs-Git: git://git@github.com:mhogomchungu/zuluCrypt.git


### PR DESCRIPTION
Hi,
thanks for your great tool and work. 
During the build on Ubuntu (see details below) with the instructions from `debian.upstream/BUILD_INSTRUCTIONS` i encountered some issues and wanted to report them / suggest a fix respectively. 
- Issues were initially caused by a deprecated dependency (**libgcrypt11-dev**). In the CI workflow also the suggested updated version is used (libgcrypt20-dev). _Are we safe to change these instructions?_
- Furthermore the **changelog** of `debian.upstream/changelog` did not get updated which results in  a dpkg-buildpackage failure for newer releases (see details below). Introducing corresponding lines in `debian.upstream/changelog` was a workaround, however changes are not signed by you ultimately.


Correlated error codes:
- E: Unable to locate package libgcrypt11-dev. libgcrypt11-dev is obsolete on modern systems. Use libgcrypt20-dev instead.
- dpkg-buildpackage -uc -us
 dpkg-source: error: can't build with source format '3.0 (quilt)': no upstream tarball found at ../zulucrypt_5.4.0.orig.tar.{bz2,gz,lzma,xz}

My system (lsb_release -a)
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 24.04.2 LTS
Release:	24.04
Codename:	noble
zuluCrypt version tested: 7.1.0